### PR TITLE
Improve phase labels in cards

### DIFF
--- a/src/cards/Classifica/calcio-live-classifica.js
+++ b/src/cards/Classifica/calcio-live-classifica.js
@@ -227,6 +227,28 @@ class CalcioLiveStandingsCard extends LitElement {
     return false;
   }
 
+  _translatePhase(phase) {
+    if (!phase) return '';
+
+    const map = {
+      'regular-season': this._t('phase.regular_season'),
+      'group stage': this._t('phase.group_stage'),
+      'playoffs': this._t('phase.playoffs'),
+    };
+
+    return map[String(phase).toLowerCase()] || phase;
+  }
+
+  _shouldShowPhase(phase) {
+    if (!phase) return false;
+
+    const lower = String(phase).toLowerCase();
+
+    if (lower === 'regular-season') return false;
+
+    return true;
+  }
+
   _zoneClass(rank, total) {
     const zones = this._getZoneConfig();
 
@@ -285,7 +307,12 @@ class CalcioLiveStandingsCard extends LitElement {
         ${this.hideHeader ? '' : html`
           <div class="top-bar">
             <h2>${stateObj.state}</h2>
-            <div class="sub">${seasonName} ${standingsGroup && standingsGroup.name ? `· ${standingsGroup.name}` : ''}</div>
+            <div class="sub">
+	       ${seasonName}
+	       ${this._shouldShowPhase(standingsGroup && standingsGroup.name)
+	        ? ` · ${this._translatePhase(standingsGroup.name)}`
+	        : ''}
+	    </div>
           </div>
         `}
 

--- a/src/cards/Team/calcio-live-team.js
+++ b/src/cards/Team/calcio-live-team.js
@@ -368,7 +368,9 @@ class CalcioLiveTeamNextCard extends LitElement {
     const showScore = isLive || isFinished;
     const competitionLabel = match.league_name && match.league_name !== 'N/A'
       ? match.league_name
-      : (match.season_info && match.season_info !== 'N/A' ? match.season_info : '');
+      : (match.season_info && match.season_info !== 'N/A' && this._shouldShowPhase(match.season_info)
+          ? this._translatePhase(match.season_info)
+          : '');
     const venue = match.venue && match.venue !== 'N/A' ? match.venue : '';
     const venueCity = match.venue_city && match.venue_city !== 'N/A' ? match.venue_city : '';
     const venueLabel = venue ? (venueCity ? `${venue}, ${venueCity}` : venue) : '—';

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -105,6 +105,10 @@ const TRANSLATIONS = {
     'zone.relegation': 'Relegation',
     'zone.conference': 'Conference League',
 
+    'phase.regular_season': 'Regular season',
+    'phase.group_stage': 'Group stage',
+    'phase.playoffs': 'Playoffs',
+
     // Standings table
     'col.pos': '#',
     'col.team': 'Team',
@@ -218,6 +222,10 @@ const TRANSLATIONS = {
 
     'news.empty': 'Geen nieuws beschikbaar',
     'news.articles': '{n} artikelen',
+
+    'phase.regular_season': 'Competitie',
+    'phase.group_stage': 'Groepsfase',
+    'phase.playoffs': 'Play-offs',
 
     'zone.champions': 'Champions League',
     'zone.europa': 'Europa League',


### PR DESCRIPTION
## Summary

Improves how phase labels are displayed across cards.

- Hides generic `regular-season` labels from the UI
- Adds translation support for common phase labels
- Keeps meaningful tournament/group labels visible
- Uses the existing i18n system

No breaking changes.